### PR TITLE
Add landing page with the example games

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -5,7 +5,8 @@ const routes: Routes = [
   { path: 'embed-game', loadChildren: () => import('./pages/embed/embed.module').then(m => m.EmbedModule) },
   { path: 'full-game', loadChildren: () => import('./pages/full-game/full-game.module').then(m => m.FullGameModule) },
   { path: 'input-game', loadChildren: () => import('./pages/input/input.module').then(m => m.InputModule) },
-  { path: '**', redirectTo: 'input-game' }
+  { path: '', loadChildren: () => import('./pages/landing/landing.module').then(m => m.LandingModule) },
+  { path: '**', redirectTo: '' }
 ];
 
 @NgModule({

--- a/src/app/pages/landing/landing-routing.module.ts
+++ b/src/app/pages/landing/landing-routing.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+
+import { LandingComponent } from './landing.component';
+
+const routes: Routes = [{ path: '', component: LandingComponent }];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class LandingRoutingModule { }

--- a/src/app/pages/landing/landing.component.html
+++ b/src/app/pages/landing/landing.component.html
@@ -16,9 +16,9 @@
     </div>
   </div>
   <div class="games">
-    <mat-card class ="game" *ngFor="let game of games"><mat-card-title>{{game.title}}</mat-card-title><mat-card-subtitle>{{game.subtitle}}</mat-card-subtitle><a mat-raised-button color="accent" href="/full-game?gameUrl={{game.url}}">Watch</a></mat-card>
+    <mat-card class="game" *ngFor="let game of games"><mat-card-title>{{game.title}}</mat-card-title><mat-card-subtitle>{{game.subtitle}}</mat-card-subtitle><a mat-raised-button color="accent" href="/full-game?gameUrl={{game.url}}">Watch</a></mat-card>
   </div>
-    <div class="row" style="justify-content: center">
+    <div class="row" style="input-wrapper">
     <a class="btn" mat-raised-button color="primary" href="/input-game">Input Your Game</a>
   </div>
 </div>

--- a/src/app/pages/landing/landing.component.html
+++ b/src/app/pages/landing/landing.component.html
@@ -16,7 +16,7 @@
     </div>
   </div>
   <div class="games">
-    <mat-card *ngFor="let game of games"><mat-card-title>{{game.title}}</mat-card-title><mat-card-subtitle>{{game.subtitle}}</mat-card-subtitle><a mat-raised-button color="accent" href="/full-game?gameUrl={{game.url}}">Watch</a></mat-card>
+    <mat-card class ="game" *ngFor="let game of games"><mat-card-title>{{game.title}}</mat-card-title><mat-card-subtitle>{{game.subtitle}}</mat-card-subtitle><a mat-raised-button color="accent" href="/full-game?gameUrl={{game.url}}">Watch</a></mat-card>
   </div>
     <div class="row" style="justify-content: center">
     <a class="btn" mat-raised-button color="primary" href="/input-game">Input Your Game</a>

--- a/src/app/pages/landing/landing.component.html
+++ b/src/app/pages/landing/landing.component.html
@@ -6,13 +6,13 @@
 <div class="container">
   <div class="row">
     <div class="col">
-      <span class="info">RootVis is a tool for visualizing Root games using <a class="link" href="https://github.com/Vagabottos/Rootlog">Rootlog</a></span>
+      <span class="mat-h1">RootVis is a tool for visualizing Root games using <a class="link" href="https://github.com/Vagabottos/Rootlog">Rootlog</a></span>
     </div>
   </div>
 
   <div class="row">
     <div class="col">
-      Watch some tournament games:
+      <span class="mat-h2">Watch some tournament games:</span>
     </div>
   </div>
   <span *ngFor="let game of games">
@@ -24,7 +24,7 @@
   </span>
   <div class="row">
     <div class="col">
-      <button><a class="btn" href="/input-game">Input Your Game</a></button>
+      <a class="btn" mat-raised-button color="primary" href="/input-game">Input Your Game</a>
     </div>
   </div>
 </div>

--- a/src/app/pages/landing/landing.component.html
+++ b/src/app/pages/landing/landing.component.html
@@ -15,16 +15,10 @@
       <span class="mat-h2">Watch some tournament games:</span>
     </div>
   </div>
-  <span *ngFor="let game of games">
-    <div class="row">
-      <div class="col">
-        <a class="link" href="/full-game?gameUrl={{game.url}}">{{game.title}}</a>
-      </div>
-    </div>
-  </span>
-  <div class="row">
-    <div class="col">
-      <a class="btn" mat-raised-button color="primary" href="/input-game">Input Your Game</a>
-    </div>
+  <div class="games">
+    <mat-card *ngFor="let game of games"><mat-card-title>{{game.title}}</mat-card-title><mat-card-subtitle>{{game.subtitle}}</mat-card-subtitle><a mat-raised-button color="accent" href="/full-game?gameUrl={{game.url}}">Watch</a></mat-card>
+  </div>
+    <div class="row" style="justify-content: center">
+    <a class="btn" mat-raised-button color="primary" href="/input-game">Input Your Game</a>
   </div>
 </div>

--- a/src/app/pages/landing/landing.component.html
+++ b/src/app/pages/landing/landing.component.html
@@ -1,0 +1,30 @@
+
+<mat-toolbar color="primary">
+  <span>Rootvis</span>
+</mat-toolbar>
+
+<div class="container">
+  <div class="row">
+    <div class="col">
+      <span class="info">RootVis is a tool for visualizing Root games using <a class="link" href="https://github.com/Vagabottos/Rootlog">Rootlog</a></span>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col">
+      Watch some tournament games:
+    </div>
+  </div>
+  <span *ngFor="let game of games">
+    <div class="row">
+      <div class="col">
+        <a class="link" href="/full-game?gameUrl={{game.url}}">{{game.title}}</a>
+      </div>
+    </div>
+  </span>
+  <div class="row">
+    <div class="col">
+      <button><a class="btn" href="/input-game">Input Your Game</a></button>
+    </div>
+  </div>
+</div>

--- a/src/app/pages/landing/landing.component.scss
+++ b/src/app/pages/landing/landing.component.scss
@@ -7,6 +7,12 @@ a:visited.link {
   color: violet;
 }
 
+.games {
+  display:  flex;
+  flex-flow: wrap row;
+  justify-content: center;
+}
+
 .mat-h1, .mat-h2 {
   text-align: center;
   width: 100%;

--- a/src/app/pages/landing/landing.component.scss
+++ b/src/app/pages/landing/landing.component.scss
@@ -1,0 +1,34 @@
+
+a.link {
+  color: pink;
+}
+
+a:visited.link {
+  color: violet;
+}
+
+.btn {
+  text-decoration: none;
+  font-weight: 700;
+  color: black;
+}
+
+.info {
+  line-height: 40px;
+  font-size: 2em;
+  white-space: pre-wrap;
+}
+
+.container {
+  padding: 10px;
+
+  .row {
+    margin-left: 20%;
+    margin-right: 20%;
+  }
+}
+
+
+.row {
+  margin-top: 10px;
+}

--- a/src/app/pages/landing/landing.component.scss
+++ b/src/app/pages/landing/landing.component.scss
@@ -13,6 +13,10 @@ a:visited.link {
   justify-content: center;
 }
 
+.game {
+  margin: 3px;
+}
+
 .mat-h1, .mat-h2 {
   text-align: center;
   width: 100%;

--- a/src/app/pages/landing/landing.component.scss
+++ b/src/app/pages/landing/landing.component.scss
@@ -7,16 +7,9 @@ a:visited.link {
   color: violet;
 }
 
-.btn {
-  text-decoration: none;
-  font-weight: 700;
-  color: black;
-}
-
-.info {
-  line-height: 40px;
-  font-size: 2em;
-  white-space: pre-wrap;
+.mat-h1, .mat-h2 {
+  text-align: center;
+  width: 100%;
 }
 
 .container {

--- a/src/app/pages/landing/landing.component.scss
+++ b/src/app/pages/landing/landing.component.scss
@@ -8,13 +8,17 @@ a:visited.link {
 }
 
 .games {
-  display:  flex;
+  display: flex;
   flex-flow: wrap row;
   justify-content: center;
 }
 
 .game {
   margin: 3px;
+}
+
+.input-wrapper {
+  justify-content: center;
 }
 
 .mat-h1, .mat-h2 {

--- a/src/app/pages/landing/landing.component.ts
+++ b/src/app/pages/landing/landing.component.ts
@@ -12,15 +12,18 @@ export class LandingComponent {
 
   games = [
     {
-      title: 'Winter Tournament - R1G3 - 3v1 chained Vagabond coalition',
+      title: '3v1 chained Vagabond coalition',
+      subtitle: 'Winter Tournament - R1G3',
       url: 'https://raw.githubusercontent.com/Vagabottos/Rootlog/master/Games/2020_11_26_winter_tournament_r1g3.rootlog'
     },
     {
-      title: 'Winter Tournament - R1G5 - Eyrie mid-game spike + Aftermath',
+      title: 'Eyrie mid-game spike + Aftermath',
+      subtitle: 'Winter Tournament - R1G5',
       url: 'https://raw.githubusercontent.com/Vagabottos/Rootlog/master/Games/2020_11_20_winter_tournament_r1g5.rootlog'
     },
     {
-      title: 'Winter Tournament - R2G4 - Otters, Mice, Cats, and Corvids',
+      title: 'Otters, Mice, Cats, and Corvids',
+      subtitle: 'Winter Tournament - R2G4',
       url: 'https://raw.githubusercontent.com/Vagabottos/Rootlog/master/Games/2020_11_24_winter_tournament_r2g4.rootlog'
     }
   ];

--- a/src/app/pages/landing/landing.component.ts
+++ b/src/app/pages/landing/landing.component.ts
@@ -12,18 +12,18 @@ export class LandingComponent {
 
   games = [
     {
-      "title": "Winter Tournament - R1G3 - 3v1 chained Vagabond coalition",
-      "url": "https://raw.githubusercontent.com/Vagabottos/Rootlog/master/Games/2020_11_26_winter_tournament_r1g3.rootlog"
+      title: 'Winter Tournament - R1G3 - 3v1 chained Vagabond coalition',
+      url: 'https://raw.githubusercontent.com/Vagabottos/Rootlog/master/Games/2020_11_26_winter_tournament_r1g3.rootlog'
     },
     {
-      "title": "Winter Tournament - R1G5 - Eyrie mid-game spike + Aftermath",
-      "url": "https://raw.githubusercontent.com/Vagabottos/Rootlog/master/Games/2020_11_20_winter_tournament_r1g5.rootlog"
+      title: 'Winter Tournament - R1G5 - Eyrie mid-game spike + Aftermath',
+      url: 'https://raw.githubusercontent.com/Vagabottos/Rootlog/master/Games/2020_11_20_winter_tournament_r1g5.rootlog'
     },
     {
-      "title": "Winter Tournament - R2G4 - Otters, Mice, Cats, and Corvids",
-      "url": "https://raw.githubusercontent.com/Vagabottos/Rootlog/master/Games/2020_11_24_winter_tournament_r2g4.rootlog"
+      title: 'Winter Tournament - R2G4 - Otters, Mice, Cats, and Corvids',
+      url: 'https://raw.githubusercontent.com/Vagabottos/Rootlog/master/Games/2020_11_24_winter_tournament_r2g4.rootlog'
     }
-  ]
+  ];
 
   constructor() {}
 }

--- a/src/app/pages/landing/landing.component.ts
+++ b/src/app/pages/landing/landing.component.ts
@@ -1,0 +1,29 @@
+import { Component } from '@angular/core';
+import { compressToEncodedURIComponent } from 'lz-string';
+
+import { RootlogService } from '../../rootlog.service';
+
+@Component({
+  selector: 'app-landing',
+  templateUrl: './landing.component.html',
+  styleUrls: ['./landing.component.scss']
+})
+export class LandingComponent {
+
+  games = [
+    {
+      "title": "Winter Tournament - R1G3 - 3v1 chained Vagabond coalition",
+      "url": "https://raw.githubusercontent.com/Vagabottos/Rootlog/master/Games/2020_11_26_winter_tournament_r1g3.rootlog"
+    },
+    {
+      "title": "Winter Tournament - R1G5 - Eyrie mid-game spike + Aftermath",
+      "url": "https://raw.githubusercontent.com/Vagabottos/Rootlog/master/Games/2020_11_20_winter_tournament_r1g5.rootlog"
+    },
+    {
+      "title": "Winter Tournament - R2G4 - Otters, Mice, Cats, and Corvids",
+      "url": "https://raw.githubusercontent.com/Vagabottos/Rootlog/master/Games/2020_11_24_winter_tournament_r2g4.rootlog"
+    }
+  ]
+
+  constructor() {}
+}

--- a/src/app/pages/landing/landing.module.ts
+++ b/src/app/pages/landing/landing.module.ts
@@ -1,0 +1,19 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { LandingRoutingModule } from './landing-routing.module';
+import { LandingComponent } from './landing.component';
+import { SharedModule } from '../../shared.module';
+import { FormsModule } from '@angular/forms';
+
+
+@NgModule({
+  declarations: [LandingComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    LandingRoutingModule,
+    SharedModule
+  ]
+})
+export class LandingModule { }


### PR DESCRIPTION
The landing page contains 3 links (out of 5) from Rootlog readme. That would help people who visit the website to get familiar with the tool.

![image](https://user-images.githubusercontent.com/4161883/152014540-e19b18db-7597-451b-bd33-5de27e729a98.png)

Note: I'm unfortunately not an expert in HTML & CSS and it's my first time with Angular. Any suggestions will be more than appreciated.